### PR TITLE
Urgent - Remove jcenter()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 
@@ -29,7 +29,6 @@ android {
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
 }
 


### PR DESCRIPTION
Android builds are failing due to `Could not resolve com.android.tools.ddms:ddmlib:26.5.3.`

## Description

https://testfairy.com/blog/jcenter-and-bintray-is-shutting-down-what-to-do/#:~:text=JCenter%20will%20no%20longer%20be,downloaded%20until%20February%201st%202022.

## Related Issue

A problem occurred configuring project ':adobe_react-native-aepassurance'.
> Could not resolve all artifacts for configuration ':adobe_react-native-aepassurance:classpath'.
   > Could not resolve com.android.tools.ddms:ddmlib:26.5.3.
     Required by:
         project :adobe_react-native-aepassurance > com.android.tools.build:gradle:3.5.3 > com.android.tools.build:builder:3.5.3
         project :adobe_react-native-aepassurance > com.android.tools.build:gradle:3.5.3 > com.android.tools.build:builder:3.5.3 > com.android.tools.build:builder-test-api:3.5.3
         project :adobe_react-native-aepassurance > com.android.tools.build:gradle:3.5.3 > com.android.tools.build:builder:3.5.3 > com.android.tools:sdk-common:26.5.3
      > Could not resolve com.android.tools.ddms:ddmlib:26.5.3.
         > Could not get resource 'https://jcenter.bintray.com/com/android/tools/ddms/ddmlib/26.5.3/ddmlib-26.5.3.pom'.
            > Could not GET 'https://jcenter.bintray.com/com/android/tools/ddms/ddmlib/26.5.3/ddmlib-26.5.3.pom'.
               > Read timed out
   > Could not resolve com.android.tools.build:apksig:3.5.3.
     Required by:
         project :adobe_react-native-aepassurance > com.android.tools.build:gradle:3.5.3 > com.android.tools.build:builder:3.5.3
      > Could not resolve com.android.tools.build:apksig:3.5.3.
         > Could not get resource 'https://jcenter.bintray.com/com/android/tools/build/apksig/3.5.3/apksig-3.5.3.pom'.
            > Could not GET 'https://jcenter.bintray.com/com/android/tools/build/apksig/3.5.3/apksig-3.5.3.pom'.
               > Read timed out
   > Could not resolve com.android.tools.build:apkzlib:3.5.3.
     Required by:
         project :adobe_react-native-aepassurance > com.android.tools.build:gradle:3.5.3 > com.android.tools.build:builder:3.5.3
      > Could not resolve com.android.tools.build:apkzlib:3.5.3.
         > Could not get resource 'https://jcenter.bintray.com/com/android/tools/build/apkzlib/3.5.3/apkzlib-3.5.3.pom'.
            > Could not GET 'https://jcenter.bintray.com/com/android/tools/build/apkzlib/3.5.3/apkzlib-3.5.3.pom'.
               > Read timed out

## Motivation and Context

Be able to build android project with this project library

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)